### PR TITLE
Removed `Dev.Fassbender.` prefix from namespaces

### DIFF
--- a/En16931/Collections/Immutable/Arrays.cs
+++ b/En16931/Collections/Immutable/Arrays.cs
@@ -4,9 +4,9 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-using Dev.Fassbender.En16931.Utils;
+using En16931.Utils;
 
-namespace Dev.Fassbender.En16931.Collections.Immutable;
+namespace En16931.Collections.Immutable;
 
 public readonly struct Array<T> : IEquatable<Array<T>> where T : struct
 {

--- a/En16931/En16931.csproj
+++ b/En16931/En16931.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Dev.Fassbender.En16931</PackageId>
+    <PackageId>En16931</PackageId>
     <Version>0.1.0</Version>
     <Authors>Jonas Fassbender</Authors>
     <Company>fassbender.dev</Company>

--- a/En16931/Model/Conversions/Conversions.cs
+++ b/En16931/Model/Conversions/Conversions.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using Dev.Fassbender.En16931.Collections.Immutable;
+using En16931.Collections.Immutable;
 
-namespace Dev.Fassbender.En16931.Model.Conversions;
+namespace En16931.Model.Conversions;
 
 public interface IToMutable<T>
 {

--- a/En16931/Model/Immutable/Immutable.cs
+++ b/En16931/Model/Immutable/Immutable.cs
@@ -1,10 +1,10 @@
-using Dev.Fassbender.En16931.Collections.Immutable;
-using Dev.Fassbender.En16931.Model.Conversions;
-using Dev.Fassbender.En16931.Model.Immutable.Primitives;
+using En16931.Collections.Immutable;
+using En16931.Model.Conversions;
+using En16931.Model.Immutable.Primitives;
 
-using Mut = Dev.Fassbender.En16931.Model;
+using Mut = En16931.Model;
 
-namespace Dev.Fassbender.En16931.Model.Immutable;
+namespace En16931.Model.Immutable;
 
 public readonly record struct Invoice : IToMutable<Mut.Invoice>
 {

--- a/En16931/Model/Immutable/Primitives/Primitives.cs
+++ b/En16931/Model/Immutable/Primitives/Primitives.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-using Dev.Fassbender.En16931.Collections.Immutable;
-using Dev.Fassbender.En16931.Model.Conversions;
-using Dev.Fassbender.En16931.Utils;
+using En16931.Collections.Immutable;
+using En16931.Model.Conversions;
+using En16931.Utils;
 
-using Mut = Dev.Fassbender.En16931.Model;
+using Mut = En16931.Model;
 
-namespace Dev.Fassbender.En16931.Model.Immutable.Primitives;
+namespace En16931.Model.Immutable.Primitives;
 
 public readonly record struct Amount(decimal Value) : IToMutable<Mut.Primitives.Amount>
 {

--- a/En16931/Model/Model.cs
+++ b/En16931/Model/Model.cs
@@ -4,13 +4,13 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
-using Dev.Fassbender.En16931.Model.Conversions;
-using Dev.Fassbender.En16931.Model.Primitives;
-using Dev.Fassbender.En16931.Utils;
+using En16931.Model.Conversions;
+using En16931.Model.Primitives;
+using En16931.Utils;
 
-using Im = Dev.Fassbender.En16931.Model.Immutable;
+using Im = En16931.Model.Immutable;
 
-namespace Dev.Fassbender.En16931.Model;
+namespace En16931.Model;
 
 [XmlRoot(ElementName = "invoice", Namespace = "urn:todo")]
 public class Invoice : IToImmutable<Im.Invoice>

--- a/En16931/Model/Primitives/Primitives.cs
+++ b/En16931/Model/Primitives/Primitives.cs
@@ -6,13 +6,13 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
-using Dev.Fassbender.En16931.Collections.Immutable;
-using Dev.Fassbender.En16931.Model.Conversions;
-using Dev.Fassbender.En16931.Utils;
+using En16931.Collections.Immutable;
+using En16931.Model.Conversions;
+using En16931.Utils;
 
-using Im = Dev.Fassbender.En16931.Model.Immutable;
+using Im = En16931.Model.Immutable;
 
-namespace Dev.Fassbender.En16931.Model.Primitives;
+namespace En16931.Model.Primitives;
 
 public struct Amount : IToImmutable<Im.Primitives.Amount>, IXmlSerializable
 {

--- a/En16931/Parser.cs
+++ b/En16931/Parser.cs
@@ -7,10 +7,10 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 using Saxon.Api;
-using Im = Dev.Fassbender.En16931.Model.Immutable;
-using Mut = Dev.Fassbender.En16931.Model;
+using Im = En16931.Model.Immutable;
+using Mut = En16931.Model;
 
-namespace Dev.Fassbender.En16931;
+namespace En16931;
 
 public class Parser
 {

--- a/En16931/Utils.cs
+++ b/En16931/Utils.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace Dev.Fassbender.En16931.Utils;
+namespace En16931.Utils;
 
 public static class Assert
 {

--- a/Tests/IR/Data.cs
+++ b/Tests/IR/Data.cs
@@ -1,7 +1,7 @@
 using System;
-using Dev.Fassbender.En16931.Collections.Immutable;
-using Dev.Fassbender.En16931.Model.Immutable;
-using Dev.Fassbender.En16931.Model.Immutable.Primitives;
+using En16931.Collections.Immutable;
+using En16931.Model.Immutable;
+using En16931.Model.Immutable.Primitives;
 
 namespace Tests.IR;
 

--- a/Tests/IR/IRTests.cs
+++ b/Tests/IR/IRTests.cs
@@ -1,8 +1,8 @@
 using System;
-using Dev.Fassbender.En16931;
-using Dev.Fassbender.En16931.Collections.Immutable;
-using Dev.Fassbender.En16931.Model.Immutable;
-using Dev.Fassbender.En16931.Model.Immutable.Primitives;
+using En16931;
+using En16931.Collections.Immutable;
+using En16931.Model.Immutable;
+using En16931.Model.Immutable.Primitives;
 using Xunit;
 
 namespace Tests.IR;

--- a/Tests/IR/Utils.cs
+++ b/Tests/IR/Utils.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Dev.Fassbender.En16931.Model.Immutable;
+using En16931.Model.Immutable;
 using Xunit;
 
 namespace Tests.IR;

--- a/Tests/XRechnung.cs
+++ b/Tests/XRechnung.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Xml.Schema;
-using Dev.Fassbender.En16931;
+using En16931;
 using Xunit;
 
 namespace Tests;


### PR DESCRIPTION
Fixes #48 